### PR TITLE
refactor: 결제 승인 구조 변경

### DIFF
--- a/back/src/main/java/com/bubble/giju/domain/order/controller/OrderController.java
+++ b/back/src/main/java/com/bubble/giju/domain/order/controller/OrderController.java
@@ -61,14 +61,4 @@ public class OrderController {
 
 
 
-    /*
-    @Operation(summary = "주문 상세 조회", description = "특정 주문의 상세 정보를 조회합니다")
-    @GetMapping("/order/{orderId}")
-    public ResponseEntity<OrderDetailResponseDto> orderDetail(
-            @PathVariable Long orderId,
-            @AuthenticationPrincipal CustomPrincipal principal) {
-        OrderDetailResponseDto detail = orderService.getOrderDetail(orderId, principal);
-        return ResponseEntity.ok(detail);
-    }*/
-
 }

--- a/back/src/main/java/com/bubble/giju/domain/payment/controller/PaymentController.java
+++ b/back/src/main/java/com/bubble/giju/domain/payment/controller/PaymentController.java
@@ -54,4 +54,6 @@ public class PaymentController {
     }
 
 
+
+
 }

--- a/back/src/main/java/com/bubble/giju/domain/payment/service/paymentImpl/PaymentServiceImpl.java
+++ b/back/src/main/java/com/bubble/giju/domain/payment/service/paymentImpl/PaymentServiceImpl.java
@@ -59,8 +59,9 @@ public class PaymentServiceImpl implements PaymentService {
         }
 
         // 결제 승인 요청
+        log.info("결제 요청들어감");
         TossPaymentResponseDto tossResponse = tossClientImpl.confirmPayment(paymentKey, orderId, amount);
-
+        log.info("결제 요청완료함");
 
         Payment payment = Payment.builder()
                 .paymentKey(tossResponse.getPaymentKey())

--- a/back/src/main/java/com/bubble/giju/domain/payment/tossClient/TossClientImpl/TossClientImpl.java
+++ b/back/src/main/java/com/bubble/giju/domain/payment/tossClient/TossClientImpl/TossClientImpl.java
@@ -14,7 +14,10 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Map;
+import java.util.UUID;
 
 @Slf4j
 @Component
@@ -28,31 +31,40 @@ public class TossClientImpl implements TossClient {
 
     @Override
     public TossPaymentResponseDto confirmPayment(String paymentKey, String orderId, int amount) {
+        String encodedKey = encodeSecretKey();
+        log.info(" Toss Authorization Header: Basic {}", encodedKey);
+
         return webClient.post()
                 .uri("/v1/payments/confirm")
-                .header(HttpHeaders.AUTHORIZATION, "Basic " + encodeSecretKey())
+                .header(HttpHeaders.AUTHORIZATION, "Basic " + encodedKey)
+                .header("Idempotency-Key", UUID.randomUUID().toString())
+                .header("Accept-Language", "ko-KR")
                 .contentType(MediaType.APPLICATION_JSON)
-                // 결제 승인에 필요한 데이터 3개를 JSON으로 보냄
+
                 .bodyValue(new TossConfirmRequest(paymentKey, orderId, amount))
 
                 // 요청을 전송하고 응답을 받을 준비
                 .retrieve()
-                .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(), clientResponse -> {
-                    return clientResponse.bodyToMono(String.class)
-                            .map(errorBody -> {
-                                log.error("Toss 결제 승인 실패: {}", errorBody);
-                                throw new CustomException(ErrorCode.PAYMENT_CONFIRMATION_FAILED);
-                            });
-                })
+                .onStatus(
+                        status -> status.is4xxClientError() || status.is5xxServerError(),
+                        response -> response.bodyToMono(String.class).map(errorBody -> {
+                            log.error(" Toss 결제 승인 실패: {}", errorBody);
+                            throw new CustomException(ErrorCode.PAYMENT_CONFIRMATION_FAILED);
+                        })
+                )
                 .bodyToMono(TossPaymentResponseDto.class)
                 .block();
     }
 
     @Override
     public TossCancelResponseDto cancelPayment(String paymentKey, String cancelReason, int cancelAmount) {
+        String encodedKey = encodeSecretKey();
+
         return webClient.post()
                 .uri("/v1/payments/" + paymentKey + "/cancel")
-                .header(HttpHeaders.AUTHORIZATION, "Basic " + encodeSecretKey())
+                .header(HttpHeaders.AUTHORIZATION, "Basic " + encodedKey)
+                .header("Idempotency-Key", UUID.randomUUID().toString())
+                .header("Accept-Language", "ko-KR")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(Map.of(
                         "cancelReason", cancelReason,
@@ -61,13 +73,10 @@ public class TossClientImpl implements TossClient {
                 .retrieve()
                 .onStatus(
                         status -> status.is4xxClientError() || status.is5xxServerError(),
-                        response -> {
-                            return response.bodyToMono(String.class)
-                                    .map(errorBody -> {
-                                        log.error("Toss 결제 취소 실패: {}", errorBody);
-                                        throw new CustomException(ErrorCode.PAYMENT_CANCEL_FAILED);
-                                    });
-                        }
+                        response -> response.bodyToMono(String.class).map(errorBody -> {
+                            log.error(" Toss 결제 취소 실패: {}", errorBody);
+                            throw new CustomException(ErrorCode.PAYMENT_CANCEL_FAILED);
+                        })
                 )
                 .bodyToMono(TossCancelResponseDto.class)
                 .block();
@@ -75,8 +84,10 @@ public class TossClientImpl implements TossClient {
 
 
     private String encodeSecretKey() {
-        return java.util.Base64.getEncoder().encodeToString((tossSecretKey + ":").getBytes());
+        return java.util.Base64.getEncoder()
+                .encodeToString((tossSecretKey + ":").getBytes(StandardCharsets.UTF_8));
     }
+
 
     // Toss 결제 승인 요청에 사용되는 내부 전용 DTO
     private record TossConfirmRequest(String paymentKey, String orderId, int amount) {}

--- a/back/src/main/java/com/bubble/giju/global/config/SecurityConfig.java
+++ b/back/src/main/java/com/bubble/giju/global/config/SecurityConfig.java
@@ -85,7 +85,7 @@ public class SecurityConfig {
         // 경로별 인가 작업
         http
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**", "/error","/api/categories").permitAll()
+                        .requestMatchers("/api/auth/**", "/error","/api/categories", "/api/payment/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/api/swagger-config/**", "/v3/api-docs/**",
                                 "/h2-console/**",
                                 "/favicon.ico",

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -56,3 +56,7 @@ jwt:
 
 springdoc:
   show-login-endpoint: true
+
+  logging:
+    level:
+      com.bubble.giju: DEBUG

--- a/back/src/main/resources/data.sql
+++ b/back/src/main/resources/data.sql
@@ -42,7 +42,7 @@ VALUES
     (100,'택배'),
     (101,'우체국 택배');
 
-INSERT INTO Orders (
+INSERT INTO orders (
     order_id,
     total_amount,
     created_at,
@@ -54,6 +54,29 @@ INSERT INTO Orders (
     user_id
 ) VALUES (
              1,
+             50000,
+             '2025-05-28T02:29:00',
+             'PENDING',
+             0,
+             false,
+             'testuser4의 테스트 주문',
+             NULL,
+             '22222222-2222-2222-2222-222222222224'
+         );
+
+
+INSERT INTO Orders (
+    order_id,
+    total_amount,
+    created_at,
+    order_status,
+    delivery_charge,
+    is_deleted,
+    order_name,
+    deleted_at,
+    user_id
+) VALUES (
+             66,
              22000,
              '2025-05-24T16:47:00',
              'PENDING',


### PR DESCRIPTION
## 📌 Summary
- Toss 결제 승인 및 취소 요청 시 사용할 TossClientImpl 클래스에서 시크릿 키 자동 주입(@Value 사용) 및
- 인증 헤더(Base64 인코딩) 처리 로직 개선
---

## ✅ Features
- @Value("${toss.secret-key}")로 시크릿 키 주입
- encodeSecretKey() 메서드를 통해 Base64 인코딩 인증 헤더 생성
- confirmPayment()에서 Idempotency-Key, Accept-Language 헤더 추가
- cancelPayment()에도 동일한 인증 및 헤더 정책 적용
- TossConfirmRequest 레코드를 내부 DTO로 간결하게 정의
- 에러 응답 body 로그로 출력: log.error("Toss 결제 승인/취소 실패: {}", errorBody);