### PR TITLE
feat: TossPayment 성공, 실패 refactor

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -52,6 +52,8 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
 
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
     // swagger
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.7.0'
 }

--- a/back/src/main/java/com/bubble/giju/domain/Page/pageController.java
+++ b/back/src/main/java/com/bubble/giju/domain/Page/pageController.java
@@ -1,12 +1,12 @@
-package com.bubble.giju.domain.payment.controller;
+package com.bubble.giju.domain.Page;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
-@RequestMapping("/api/payment")
-public class paymentController2 {
+@RequestMapping("/toss")
+public class pageController {
     @GetMapping("/page")
     public String paymentPage() {
         return "payment";  // payment.html 렌더링

--- a/back/src/main/java/com/bubble/giju/domain/order/entity/Order.java
+++ b/back/src/main/java/com/bubble/giju/domain/order/entity/Order.java
@@ -71,6 +71,7 @@ public class Order {
 
     }
 
+
     public void addOrderDetail(OrderDetail orderDetail) {
         this.orderDetails.add(orderDetail);
 

--- a/back/src/main/java/com/bubble/giju/domain/order/entity/Order.java
+++ b/back/src/main/java/com/bubble/giju/domain/order/entity/Order.java
@@ -3,6 +3,10 @@ package com.bubble.giju.domain.order.entity;
 import com.bubble.giju.domain.payment.entity.Payment;
 import com.bubble.giju.domain.user.entity.User;
 
+import com.bubble.giju.global.config.CustomException;
+import com.bubble.giju.global.config.ErrorCode;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -51,6 +55,9 @@ public class Order {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+    @Column(name = "used_cart_ids", columnDefinition = "TEXT")
+    private String usedCartIds;
+
     @ManyToOne(fetch = FetchType.LAZY) //user 테이블
     @JoinColumn(name = "user_id", nullable = false, referencedColumnName = "user_id")
     private User user;
@@ -85,5 +92,15 @@ public class Order {
     public void softDelete() {
         this.isDeleted = true;
         this.deletedAt = LocalDateTime.now();
+    }
+
+    // 주문 생성 시 사용된 Cart ID 리스트를 JSON 문자열로 저장하는 메서드
+    public void setUsedCartIds(List<Long> cartItemIds) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            this.usedCartIds = objectMapper.writeValueAsString(cartItemIds);
+        } catch (JsonProcessingException e) {
+            throw new CustomException(ErrorCode.JSON_PROCESSING_ERROR);
+        }
     }
 }

--- a/back/src/main/java/com/bubble/giju/domain/order/entity/OrderCartMapping.java
+++ b/back/src/main/java/com/bubble/giju/domain/order/entity/OrderCartMapping.java
@@ -1,0 +1,32 @@
+package com.bubble.giju.domain.order.entity;
+
+import com.bubble.giju.domain.cart.entity.Cart;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "order_cart_mapping")
+public class OrderCartMapping {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cart_id", nullable = false)
+    private Cart cart;
+
+    @Builder
+    public OrderCartMapping(Order order, Cart cart) {
+        this.order = order;
+        this.cart = cart;
+    }
+}

--- a/back/src/main/java/com/bubble/giju/domain/order/repository/OrderCartMappingRepository.java
+++ b/back/src/main/java/com/bubble/giju/domain/order/repository/OrderCartMappingRepository.java
@@ -1,0 +1,14 @@
+package com.bubble.giju.domain.order.repository;
+
+import com.bubble.giju.domain.order.entity.Order;
+import com.bubble.giju.domain.order.entity.OrderCartMapping;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OrderCartMappingRepository extends JpaRepository<OrderCartMapping, Long> {
+
+    List<OrderCartMapping> findByOrder(Order order);
+
+    void deleteByOrder(Order order);
+}

--- a/back/src/main/java/com/bubble/giju/domain/order/service/serviceImpl/OrderServiceImpl.java
+++ b/back/src/main/java/com/bubble/giju/domain/order/service/serviceImpl/OrderServiceImpl.java
@@ -6,8 +6,10 @@ import com.bubble.giju.domain.drink.entity.Drink;
 import com.bubble.giju.domain.order.dto.request.RefundRequestDto;
 import com.bubble.giju.domain.order.dto.response.*;
 import com.bubble.giju.domain.order.entity.Order;
+import com.bubble.giju.domain.order.entity.OrderCartMapping;
 import com.bubble.giju.domain.order.entity.OrderDetail;
 import com.bubble.giju.domain.order.entity.OrderStatus;
+import com.bubble.giju.domain.order.repository.OrderCartMappingRepository;
 import com.bubble.giju.domain.order.repository.OrderDetailRepository;
 import com.bubble.giju.domain.order.repository.OrderRepository;
 import com.bubble.giju.domain.order.service.OrderService;
@@ -38,6 +40,7 @@ public class OrderServiceImpl implements OrderService {
     private final CartRepository cartRepository;
     private final PaymentRepository paymentRepository;
     private final OrderDetailRepository orderDetailRepository;
+    private final OrderCartMappingRepository orderCartMappingRepository;
 
     @Value("${app.base-url}")
     private String baseUrl;
@@ -75,27 +78,38 @@ public class OrderServiceImpl implements OrderService {
                 .user(user)
                 .build();
 
-        for (Cart cart : cartItems) {
-            Drink drink = cart.getDrink();
-            int price = drink.getPrice();
-            int quantity = cart.getQuantity();
+        // 주문 상세(OrderDetail) 리스트 생성 및 양방향 매핑
+        List<OrderDetail> orderDetails = cartItems.stream()
+                .map(cart -> {
+                    Drink drink = cart.getDrink();
+                    return OrderDetail.builder()
+                            .drinkName(drink.getName())
+                            .price(drink.getPrice() * cart.getQuantity())
+                            .quantity(cart.getQuantity())
+                            .order(order)
+                            .region(drink.getRegion())
+                            .build();
+                })
+                .toList();
 
-            // orderDetail 생성
-            OrderDetail orderDetail = OrderDetail.builder()
-                    .drinkName(drink.getName())
-                    .price(price*quantity)
-                    .quantity(quantity)
-                    .order(order)
-                    .region(drink.getRegion())
-                    .build();
-            //양뱡향 설정
-            order.addOrderDetail(orderDetail);
-        }
+        orderDetails.forEach(order::addOrderDetail); // 양방향 연관관계
+
+        // 주문 저장
         Order savedOrder = orderRepository.save(order);
 
+        List<OrderCartMapping> mappings = cartItems.stream()
+                .map(cart -> OrderCartMapping.builder()
+                        .order(savedOrder)
+                        .cart(cart)
+                        .build())
+                .toList();
+
+        orderCartMappingRepository.saveAll(mappings);
+
+        String tossOrderId = String.format("ORDER%06d", savedOrder.getId()); //토스페이먼츠서버로 보내기 위해 orderId는 6~64자, 영문 대소문자, 숫자, -, _만 가능 변환
 
         return OrderResponseDto.builder()
-                .orderId(savedOrder.getId().toString()) //토스페이먼츠서버로 보내기 위해 String변환
+                .orderId( tossOrderId)
                 .amount(savedOrder.getTotalAmount() + savedOrder.getDeliveryCharge()) // 상품값 + 배달비
                 .orderName(savedOrder.getOrderName())
                 .customerEmail(user.getEmail())

--- a/back/src/main/java/com/bubble/giju/domain/order/service/serviceImpl/OrderServiceImpl.java
+++ b/back/src/main/java/com/bubble/giju/domain/order/service/serviceImpl/OrderServiceImpl.java
@@ -106,7 +106,8 @@ public class OrderServiceImpl implements OrderService {
 
         orderCartMappingRepository.saveAll(mappings);
 
-        String tossOrderId = String.format("ORDER%06d", savedOrder.getId()); //토스페이먼츠서버로 보내기 위해 orderId는 6~64자, 영문 대소문자, 숫자, -, _만 가능 변환
+        String tossOrderId = "ORDER_" + savedOrder.getId() + "_" + UUID.randomUUID();
+        //String tossOrderId = String.format("ORDER%06d", savedOrder.getId()); //토스페이먼츠서버로 보내기 위해 orderId는 6~64자, 영문 대소문자, 숫자, -, _만 가능 변환
 
         return OrderResponseDto.builder()
                 .orderId( tossOrderId)

--- a/back/src/main/java/com/bubble/giju/domain/payment/controller/PaymentController.java
+++ b/back/src/main/java/com/bubble/giju/domain/payment/controller/PaymentController.java
@@ -46,7 +46,7 @@ public class PaymentController {
 
     @PreAuthorize("hasRole('USER')")
     @Operation(summary = "결제 취소", description = "선택한 상품 또는 전체 결제 금액을 취소 처리, isFullCancel는 전체 취소인지 아닌지 판별용, 주문상태가 SUCCEEDED 만 사용")
-    @PostMapping("/{order_id}/cancel")
+    @PostMapping("/cancel")
     public ResponseEntity<ApiResponse<PaymentCancelResponseDto>> cancelPayment(@AuthenticationPrincipal CustomPrincipal customPrincipal, @RequestBody PaymentCancelRequestDto paymentCancelRequestDto) {
         PaymentCancelResponseDto cancel = paymentService.paymentCancel(customPrincipal, paymentCancelRequestDto);
         ApiResponse<PaymentCancelResponseDto> response = ApiResponse.success("결제 취소 성공",cancel);

--- a/back/src/main/java/com/bubble/giju/domain/payment/controller/paymentController2.java
+++ b/back/src/main/java/com/bubble/giju/domain/payment/controller/paymentController2.java
@@ -1,0 +1,15 @@
+package com.bubble.giju.domain.payment.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/api/payment")
+public class paymentController2 {
+    @GetMapping("/page")
+    public String paymentPage() {
+        return "payment";  // payment.html 렌더링
+    }
+
+}

--- a/back/src/main/java/com/bubble/giju/domain/payment/service/paymentImpl/PaymentServiceImpl.java
+++ b/back/src/main/java/com/bubble/giju/domain/payment/service/paymentImpl/PaymentServiceImpl.java
@@ -1,10 +1,13 @@
 package com.bubble.giju.domain.payment.service.paymentImpl;
 
+import com.bubble.giju.domain.cart.entity.Cart;
 import com.bubble.giju.domain.cart.repository.CartRepository;
 import com.bubble.giju.domain.order.entity.Order;
 
+import com.bubble.giju.domain.order.entity.OrderCartMapping;
 import com.bubble.giju.domain.order.entity.OrderStatus;
 
+import com.bubble.giju.domain.order.repository.OrderCartMappingRepository;
 import com.bubble.giju.domain.order.repository.OrderRepository;
 import com.bubble.giju.domain.payment.dto.request.CanceledItemDto;
 import com.bubble.giju.domain.payment.dto.request.PaymentCancelRequestDto;
@@ -27,6 +30,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 
+import java.util.List;
 import java.util.UUID;
 
 
@@ -40,6 +44,7 @@ public class PaymentServiceImpl implements PaymentService {
     private final PaymentRepository paymentRepository;
     private final PaymentCancelInfoRepository paymentCancelInfoRepository;
     private final PaymentFailInfoRepository paymentFailInfoRepository;
+    private final OrderCartMappingRepository orderCartMappingRepository;
 
     private static final String CANCEL_REASON = "결제 정보 불일치로 인한 자동 취소";
     private final CartRepository cartRepository;
@@ -83,7 +88,7 @@ public class PaymentServiceImpl implements PaymentService {
 
         //추가 검증
         if (!orderId.equals(tossResponse.getOrderId()) ||
-                order.getTotalAmount() != tossResponse.getTotalAmount()) {
+            order.getTotalAmount() != tossResponse.getTotalAmount()) {
 
             //결제 취소
             TossCancelResponseDto cancelResponse = tossClientImpl.cancelPayment(
@@ -117,9 +122,8 @@ public class PaymentServiceImpl implements PaymentService {
         order.updateStatus(OrderStatus.SUCCEEDED);
         orderRepository.save(order);
 
-
-        //결제 성공시 장바구니 삭제
-        cartRepository.deleteByUser(order.getUser());
+        //장바구니 정리
+        deleteCartsAndMappingsByOrder(order);
     }
 
 
@@ -236,6 +240,16 @@ public class PaymentServiceImpl implements PaymentService {
         // DB에서 주문 조회
         return orderRepository.findById(orderIdLong)
                 .orElseThrow(() -> new CustomException(ErrorCode.NON_EXISTENT_ORDER));
+    }
+
+    private void deleteCartsAndMappingsByOrder(Order order) {
+        List<Cart> cartsToDelete = orderCartMappingRepository.findByOrder(order)
+                .stream()
+                .map(OrderCartMapping::getCart)
+                .toList();
+
+        cartRepository.deleteAll(cartsToDelete);
+        orderCartMappingRepository.deleteByOrder(order);
     }
 
 

--- a/back/src/main/java/com/bubble/giju/domain/payment/service/paymentImpl/PaymentServiceImpl.java
+++ b/back/src/main/java/com/bubble/giju/domain/payment/service/paymentImpl/PaymentServiceImpl.java
@@ -61,9 +61,10 @@ public class PaymentServiceImpl implements PaymentService {
             throw new CustomException(ErrorCode.INVALID_PAYMENT_VERIFICATION);
         }
 
-//        if (order.isDeleted()) {
-//            throw new CustomException(ErrorCode.ALREADY_DELETED_ORDER);
-//        }
+        //soft delete 된 건지 판단
+        if (order.isDeleted()) {
+            throw new CustomException(ErrorCode.ALREADY_DELETED_ORDER);
+        }
 
         // 결제 승인 요청
         log.info("결제 요청들어감");
@@ -220,27 +221,24 @@ public class PaymentServiceImpl implements PaymentService {
                 .build();
     }
 
-
     public Order findOrderByStringId(String orderId) {
-        // 숫자 아닌 문자 모두 제거
-        String orderIdStr = orderId.replaceAll("[^0-9]", "");
+        String[] parts = orderId.split("_");
 
-        if (orderIdStr.isEmpty()) {
-            throw new CustomException(ErrorCode.INVALID_ORDER_ID);
+        if (parts.length < 3) {
+            throw new CustomException(ErrorCode.INVALID_ORDER_ID_FORMAT);
         }
 
-        // Long 타입으로 변환
         Long orderIdLong;
         try {
-            orderIdLong = Long.parseLong(orderIdStr);
+            orderIdLong = Long.parseLong(parts[1]);  // 두 번째 파트가 숫자 ID
         } catch (NumberFormatException e) {
             throw new CustomException(ErrorCode.INVALID_ORDER_ID_FORMAT);
         }
 
-        // DB에서 주문 조회
         return orderRepository.findById(orderIdLong)
                 .orElseThrow(() -> new CustomException(ErrorCode.NON_EXISTENT_ORDER));
     }
+
 
     private void deleteCartsAndMappingsByOrder(Order order) {
         List<Cart> cartsToDelete = orderCartMappingRepository.findByOrder(order)
@@ -265,4 +263,25 @@ public class PaymentServiceImpl implements PaymentService {
         paymentRepository.save(payment);
     }
 
+
+    /*  public Order findOrderByStringId(String orderId) {
+        // 숫자 아닌 문자 모두 제거
+        String orderIdStr = orderId.replaceAll("[^0-9]", "");
+
+        if (orderIdStr.isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_ORDER_ID);
+        }
+
+        // Long 타입으로 변환
+        Long orderIdLong;
+        try {
+            orderIdLong = Long.parseLong(orderIdStr);
+        } catch (NumberFormatException e) {
+            throw new CustomException(ErrorCode.INVALID_ORDER_ID_FORMAT);
+        }
+
+        // DB에서 주문 조회
+        return orderRepository.findById(orderIdLong)
+                .orElseThrow(() -> new CustomException(ErrorCode.NON_EXISTENT_ORDER));
+    }*/
 }

--- a/back/src/main/java/com/bubble/giju/domain/payment/service/paymentImpl/PaymentServiceImpl.java
+++ b/back/src/main/java/com/bubble/giju/domain/payment/service/paymentImpl/PaymentServiceImpl.java
@@ -48,19 +48,17 @@ public class PaymentServiceImpl implements PaymentService {
     @Override
     public void paymentSuccess(String paymentKey, String orderId, int amount) {
 
-        // TossPayment -> orderId 타입이 Long
-        Long orderIdToss = Long.parseLong(orderId);
-        // Order 테이블에서 실제 주문 조회
-        Order order = getOrder(orderIdToss);
+
+        Order order = findOrderByStringId(orderId);
 
         // 결제 버튼 누를때 생성된 Order의 총값 과 리다이렉트 파라미터 비교
         if (order.getTotalAmount() != amount) {
             throw new CustomException(ErrorCode.INVALID_PAYMENT_VERIFICATION);
         }
 
-        if (order.isDeleted()) {
-            throw new CustomException(ErrorCode.ALREADY_DELETED_ORDER);
-        }
+//        if (order.isDeleted()) {
+//            throw new CustomException(ErrorCode.ALREADY_DELETED_ORDER);
+//        }
 
         // 결제 승인 요청
         log.info("결제 요청들어감");
@@ -129,8 +127,7 @@ public class PaymentServiceImpl implements PaymentService {
     @Override
     public void paymentFail(String code, String message, String orderId) {
 
-        Long orderIdToss = Long.parseLong(orderId);
-        Order order = getOrder(orderIdToss);
+        Order order = findOrderByStringId(orderId);
 
         // 실패 상태의 Payment 생성
         Payment payment = Payment.builder()
@@ -220,10 +217,27 @@ public class PaymentServiceImpl implements PaymentService {
     }
 
 
-    private Order getOrder(Long orderId) {
-        return orderRepository.findById(orderId)
+    public Order findOrderByStringId(String orderId) {
+        // 숫자 아닌 문자 모두 제거
+        String orderIdStr = orderId.replaceAll("[^0-9]", "");
+
+        if (orderIdStr.isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_ORDER_ID);
+        }
+
+        // Long 타입으로 변환
+        Long orderIdLong;
+        try {
+            orderIdLong = Long.parseLong(orderIdStr);
+        } catch (NumberFormatException e) {
+            throw new CustomException(ErrorCode.INVALID_ORDER_ID_FORMAT);
+        }
+
+        // DB에서 주문 조회
+        return orderRepository.findById(orderIdLong)
                 .orElseThrow(() -> new CustomException(ErrorCode.NON_EXISTENT_ORDER));
     }
+
 
     private void updateCanceledPayment(Payment payment, TossCancelResponseDto response) {
         TossCancelResponseDto.CancelDetail latest = response.getLatestCancel();

--- a/back/src/main/java/com/bubble/giju/domain/payment/service/paymentImpl/PaymentServiceImpl.java
+++ b/back/src/main/java/com/bubble/giju/domain/payment/service/paymentImpl/PaymentServiceImpl.java
@@ -58,6 +58,10 @@ public class PaymentServiceImpl implements PaymentService {
             throw new CustomException(ErrorCode.INVALID_PAYMENT_VERIFICATION);
         }
 
+        if (order.isDeleted()) {
+            throw new CustomException(ErrorCode.ALREADY_DELETED_ORDER);
+        }
+
         // 결제 승인 요청
         log.info("결제 요청들어감");
         TossPaymentResponseDto tossResponse = tossClientImpl.confirmPayment(paymentKey, orderId, amount);

--- a/back/src/main/java/com/bubble/giju/domain/payment/tossClient/TossClientImpl/TossClientImpl.java
+++ b/back/src/main/java/com/bubble/giju/domain/payment/tossClient/TossClientImpl/TossClientImpl.java
@@ -26,8 +26,8 @@ public class TossClientImpl implements TossClient {
 
     private final WebClient webClient;
 
-    //@Value("${toss.secret-key}")
-    private String tossSecretKey = "test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6";
+    @Value("${toss.secret-key}")
+    private String tossSecretKey;
 
 
     @Override
@@ -35,7 +35,7 @@ public class TossClientImpl implements TossClient {
         String encodedKey = encodeSecretKey();
 
 
-        // 🔍 [2] 승인 요청 데이터 확인
+        //승인 요청 데이터 확인
         log.info("요청 데이터 → paymentKey: {}, orderId: {}, amount: {}", paymentKey, orderId, amount);
         TossConfirmRequest requestBody = new TossConfirmRequest(paymentKey, orderId, amount);
         log.info("HTTP 요청 바디: {}", requestBody); // record이므로 toString() 자동 사용됨

--- a/back/src/main/java/com/bubble/giju/domain/payment/tossClient/TossClientImpl/TossClientImpl.java
+++ b/back/src/main/java/com/bubble/giju/domain/payment/tossClient/TossClientImpl/TossClientImpl.java
@@ -26,13 +26,19 @@ public class TossClientImpl implements TossClient {
 
     private final WebClient webClient;
 
-    @Value("${toss.secret-key}")
-    private String tossSecretKey;
+    //@Value("${toss.secret-key}")
+    private String tossSecretKey = "test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6";
+
 
     @Override
     public TossPaymentResponseDto confirmPayment(String paymentKey, String orderId, int amount) {
         String encodedKey = encodeSecretKey();
-        log.info(" Toss Authorization Header: Basic {}", encodedKey);
+
+
+        // 🔍 [2] 승인 요청 데이터 확인
+        log.info("요청 데이터 → paymentKey: {}, orderId: {}, amount: {}", paymentKey, orderId, amount);
+        TossConfirmRequest requestBody = new TossConfirmRequest(paymentKey, orderId, amount);
+        log.info("HTTP 요청 바디: {}", requestBody); // record이므로 toString() 자동 사용됨
 
         return webClient.post()
                 .uri("/v1/payments/confirm")

--- a/back/src/main/java/com/bubble/giju/global/config/ErrorCode.java
+++ b/back/src/main/java/com/bubble/giju/global/config/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
     NON_EXISTENT_ORDER("주문이 존재 하지않습니다",HttpStatus.BAD_REQUEST),
     CANNOT_REFUND_THIS_ORDER("해당 주문은 환불할 수 없는 상태입니다", HttpStatus.BAD_REQUEST),
     INVALID_REFUND_ITEM("유효하지 않은 환불 요청 항목입니다", HttpStatus.BAD_REQUEST),
+    ALREADY_DELETED_ORDER("결제 시간 초과로 소프트삭제도니 주문 입니다",HttpStatus.BAD_REQUEST),
 
     /**
      * PAYMENT

--- a/back/src/main/java/com/bubble/giju/global/config/ErrorCode.java
+++ b/back/src/main/java/com/bubble/giju/global/config/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
     CANNOT_REFUND_THIS_ORDER("해당 주문은 환불할 수 없는 상태입니다", HttpStatus.BAD_REQUEST),
     INVALID_REFUND_ITEM("유효하지 않은 환불 요청 항목입니다", HttpStatus.BAD_REQUEST),
     ALREADY_DELETED_ORDER("결제 시간 초과로 소프트삭제도니 주문 입니다",HttpStatus.BAD_REQUEST),
+    JSON_PROCESSING_ERROR("Cart ID 저장 중 올 발생", HttpStatus.BAD_REQUEST),
 
     /**
      * PAYMENT
@@ -55,6 +56,7 @@ public enum ErrorCode {
     UNAUTHORIZED_USER("해당 주문에 대한 권한이 없습니다", HttpStatus.FORBIDDEN),
     CANNOT_CANCEL_THIS_ORDER("해당 주문은 현재 취소할 수 없는 상태입니다", HttpStatus.BAD_REQUEST),
     UNAUTHORIZED_CANCEL_ACCESS("해당 주문에 대한 결제 취소 권한이 없습니다", HttpStatus.BAD_REQUEST),
+    INVALID_ORDER_ID_FORMAT("주문ID 변환 실패", HttpStatus.BAD_REQUEST),
 
     /**
      * Ranking

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -41,7 +41,7 @@ logging:
 order:
   targetPrice: 30000
   delivery-charge: 3000
-  cleanup-expiration-minutes: 15
+  cleanup-expiration-minutes: 20
   delete-cycle: 30
 
 toss:

--- a/back/src/main/resources/data.sql
+++ b/back/src/main/resources/data.sql
@@ -135,7 +135,7 @@ INSERT INTO orders (
     deleted_at,
     user_id
 ) VALUES (
-             1,
+             99,
              50000,
              '2025-05-28T02:29:00',
              'PENDING',
@@ -146,6 +146,18 @@ INSERT INTO orders (
              '22222222-2222-2222-2222-222222222224'
          );
 
+
+INSERT INTO order_detail (order_detail_id,
+                          price,
+                          quantity,
+                          drink_name,
+                          region,
+                          order_id,
+                          is_canceled,
+                          is_refund_requested,
+                          is_refunded)
+VALUES (1, 10000, 1, '막걸리', '전라남도', 99, false, false, false),
+       (2, 12000, 1, '감자주', '강원도', 99, false, false, false);
 
 INSERT INTO Orders (
     order_id,
@@ -158,7 +170,7 @@ INSERT INTO Orders (
     deleted_at,
     user_id
 ) VALUES (
-             67,
+             1,
              50000,
              '2025-05-24T16:47:00',
              'PENDING',
@@ -169,17 +181,7 @@ INSERT INTO Orders (
              '11111111-1111-1111-1111-111111111112'
          );
 
-INSERT INTO order_detail (order_detail_id,
-                          price,
-                          quantity,
-                          drink_name,
-                          region,
-                          order_id,
-                          is_canceled,
-                          is_refund_requested,
-                          is_refunded)
-VALUES (1, 10000, 1, '막걸리', '전라남도', 1, false, false, false),
-       (2, 12000, 1, '감자주', '강원도', 1, false, false, false);
+
 
 
 INSERT INTO Orders (order_id,

--- a/back/src/main/resources/data.sql
+++ b/back/src/main/resources/data.sql
@@ -158,8 +158,8 @@ INSERT INTO Orders (
     deleted_at,
     user_id
 ) VALUES (
-             66,
-             22000,
+             67,
+             50000,
              '2025-05-24T16:47:00',
              'PENDING',
              3000,

--- a/back/src/main/resources/templates/payment.html
+++ b/back/src/main/resources/templates/payment.html
@@ -25,7 +25,7 @@
         const coupon = document.getElementById("coupon-box");
         // ------  Initialize widget ------
 
-        const clientKey = "";
+        const clientKey = "클라이언트 키 넣어줘";
         const tossPayments = TossPayments(clientKey);
         // Logged in customers
         const customerKey = "ne93IVS3YN7kaA_Ag7Dts";

--- a/back/src/main/resources/templates/payment.html
+++ b/back/src/main/resources/templates/payment.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="utf-8" />
+    <script src="https://js.tosspayments.com/v2/standard"></script>
+</head>
+<body>
+<!-- Discount coupon -->
+<div>
+    <input type="checkbox" id="coupon-box" />
+    <label for="coupon-box"> 5,000원 쿠폰 적용 </label>
+</div>
+<!-- Payment UI -->
+<div id="payment-method"></div>
+<!-- Agreement UI -->
+<div id="agreement"></div>
+<!-- Pay now button -->
+<button class="button" id="payment-button" style="margin-top: 30px">Pay now</button>
+
+<script>
+    main();
+
+    async function main() {
+        const button = document.getElementById("payment-button");
+        const coupon = document.getElementById("coupon-box");
+        // ------  Initialize widget ------
+        const clientKey = "test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm";
+        const tossPayments = TossPayments(clientKey);
+        // Logged in customers
+        const customerKey = "ne93IVS3YN7kaA_Ag7Dts";
+        const widgets = tossPayments.widgets({
+            customerKey,
+        });
+        // Other customers
+        // const widgets = tossPayments.widgets({ customerKey: TossPayments.ANONYMOUS });
+
+        // ------ Set payment amount ------
+        await widgets.setAmount({
+            currency: "KRW",
+            value: 50000,
+        });
+
+        await Promise.all([
+            // ------  Render payment UI ------
+            widgets.renderPaymentMethods({
+                selector: "#payment-method",
+                variantKey: "DEFAULT",
+            }),
+            // ------  Render agreement UI ------
+            widgets.renderAgreement({ selector: "#agreement", variantKey: "AGREEMENT" }),
+        ]);
+
+        // ------  Update payment amount if necessary ------
+        coupon.addEventListener("change", async function () {
+            if (coupon.checked) {
+                await widgets.setAmount({
+                    currency: "KRW",
+                    value: 50000 - 5000,
+                });
+
+                return;
+            }
+
+            await widgets.setAmount({
+                currency: "KRW",
+                value: 50000,
+            });
+        });
+
+        // ------ Open payment method ------
+        // Save the amount and orderId to prevent malicious attempts to change them
+        button.addEventListener("click", async function () {
+            await widgets.requestPayment({
+                orderId: "ORDER0000067",
+                orderName: "토스 티셔츠 외 2건",
+                successUrl: "http://localhost:8080/api/payment/success",
+                failUrl: "http://localhost:8080/api/payment/fail",
+                customerEmail: "customer123@gmail.com",
+                customerName: "김토스",
+                customerMobilePhone: "01012341234",
+            });
+        });
+    }
+</script>
+</body>
+</html>

--- a/back/src/main/resources/templates/payment.html
+++ b/back/src/main/resources/templates/payment.html
@@ -24,7 +24,8 @@
         const button = document.getElementById("payment-button");
         const coupon = document.getElementById("coupon-box");
         // ------  Initialize widget ------
-        const clientKey = "test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm";
+
+        const clientKey = "";
         const tossPayments = TossPayments(clientKey);
         // Logged in customers
         const customerKey = "ne93IVS3YN7kaA_Ag7Dts";
@@ -71,7 +72,7 @@
         // Save the amount and orderId to prevent malicious attempts to change them
         button.addEventListener("click", async function () {
             await widgets.requestPayment({
-                orderId: "ORDER0000067",
+                orderId: "ORDER0000099",
                 orderName: "토스 티셔츠 외 2건",
                 successUrl: "http://localhost:8080/api/payment/success",
                 failUrl: "http://localhost:8080/api/payment/fail",

--- a/back/src/test/java/com/bubble/giju/order/service/OrderServiceImplTest.java
+++ b/back/src/test/java/com/bubble/giju/order/service/OrderServiceImplTest.java
@@ -5,6 +5,7 @@ import com.bubble.giju.domain.cart.repository.CartRepository;
 import com.bubble.giju.domain.drink.entity.Drink;
 import com.bubble.giju.domain.order.dto.response.OrderResponseDto;
 import com.bubble.giju.domain.order.entity.Order;
+import com.bubble.giju.domain.order.repository.OrderCartMappingRepository;
 import com.bubble.giju.domain.order.repository.OrderRepository;
 import com.bubble.giju.domain.order.service.serviceImpl.OrderServiceImpl;
 import com.bubble.giju.domain.user.dto.CustomPrincipal;
@@ -37,7 +38,7 @@ public class OrderServiceImplTest {
     @Mock private OrderRepository orderRepository;
     @Mock private UserRepository userRepository;
     @Mock private CartRepository cartRepository;
-
+    @Mock private OrderCartMappingRepository orderCartMappingRepository;
     @InjectMocks
     private OrderServiceImpl orderService;
 


### PR DESCRIPTION
## 📌 Summary
- TossPayments 결제 요청 시 중복 방지를 위해 orderId 생성 로직을 UUID 포함 방식으로 변경
- OrderCartMapping 엔티티 추가로 Order와 Cart의 N:M 관계 명확화
- Thymeleaf 통해  payment.html  추가 후 테스트 진행

## ✅ Features
- OrderCartMapping 엔티티 생성
 -  @ManyToOne 방식으로 Order, Cart를 매핑
 - deleteByOrder() 구현으로 연관 삭제 처리 가능

- tossOrderId 생성 로직 리팩토링
  - 기존: "ORDER000001"
  - 변경: "ORDER_{id}_{UUID}" 형식으로 중복 및 충돌 방지
- OrderService.findOrderByStringId() 로직도 해당 포맷에 맞게 수정