### PR TITLE
feat: 장바구니 추가시 이미지 함께 반환

### DIFF
--- a/back/src/main/java/com/bubble/giju/domain/cart/dto/response/CartItemResponseDto.java
+++ b/back/src/main/java/com/bubble/giju/domain/cart/dto/response/CartItemResponseDto.java
@@ -1,5 +1,6 @@
 package com.bubble.giju.domain.cart.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,20 +8,35 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class CartItemResponseDto {
+    @Schema(description = "장바구니 ID")
     private Long cartId;
+
+    @Schema(description = "주류ID")
     private Long drinkId;
+
+    @Schema(description = "주류 이름")
     private String drinkName;
+
+    @Schema(description = "수량")
     private int quantity;
+
+    @Schema(description = "상품 1개 가격")
     private int unitPrice;
+
+    @Schema(description = "상품*수량 = 가격")
     private int totalPrice;
 
+    @Schema(description = "대표 사진url")
+    private String imageUrl;
+
     @Builder
-    public CartItemResponseDto (Long cartId, Long drinkId, String drinkName ,int quantity, int unitPrice, int totalPrice) {
+    public CartItemResponseDto (Long cartId, Long drinkId, String drinkName ,int quantity, int unitPrice, int totalPrice, String imageUrl) {
         this.cartId = cartId;
         this.drinkId = drinkId;
         this.drinkName = drinkName;
         this.quantity = quantity;
         this.unitPrice = unitPrice;
         this.totalPrice = totalPrice;
+        this.imageUrl = imageUrl;
     }
 }

--- a/back/src/main/java/com/bubble/giju/domain/cart/service/serviceImpl/CartServiceImpl.java
+++ b/back/src/main/java/com/bubble/giju/domain/cart/service/serviceImpl/CartServiceImpl.java
@@ -140,6 +140,7 @@ public class CartServiceImpl implements CartService {
 
     @Override
     public void deleteCartItem(List<Long> cartId, CustomPrincipal principal) {
+
         User user = userRepository.findById(UUID.fromString(principal.getUserId()))
                 .orElseThrow(() -> new CustomException(ErrorCode.NON_EXISTENT_USER));
 

--- a/back/src/main/java/com/bubble/giju/domain/cart/service/serviceImpl/CartServiceImpl.java
+++ b/back/src/main/java/com/bubble/giju/domain/cart/service/serviceImpl/CartServiceImpl.java
@@ -9,6 +9,7 @@ import com.bubble.giju.domain.cart.entity.Cart;
 import com.bubble.giju.domain.cart.repository.CartRepository;
 import com.bubble.giju.domain.cart.service.CartService;
 import com.bubble.giju.domain.drink.entity.Drink;
+import com.bubble.giju.domain.drink.repository.DrinkImageRepository;
 import com.bubble.giju.domain.drink.repository.DrinkRepository;
 import com.bubble.giju.domain.user.dto.CustomPrincipal;
 import com.bubble.giju.domain.user.entity.User;
@@ -36,6 +37,7 @@ public class CartServiceImpl implements CartService {
     private final CartRepository cartRepository;
     private final DrinkRepository drinkRepository;
     private final UserRepository userRepository;
+    private final DrinkImageRepository drinkImageRepository;
 
     @Value("${order.delivery-charge}")
     private int deliveryCharge;
@@ -120,6 +122,11 @@ public class CartServiceImpl implements CartService {
     // 각 상품의 값
     private CartItemResponseDto toCartItemDto(Cart cart) {
         Drink drink = cart.getDrink();
+
+        String imageUrl = drinkImageRepository.findFirstByDrinkAndThumbnailTrue(drink)
+                .map(drinkImage -> drinkImage.getImage().getUrl())
+                .orElseThrow(() -> new CustomException(ErrorCode.THUMBNAIL_IMAGE_NOT_FOUND));
+
         return CartItemResponseDto.builder()
                 .cartId(cart.getId())
                 .drinkId(drink.getId())
@@ -127,6 +134,7 @@ public class CartServiceImpl implements CartService {
                 .quantity(cart.getQuantity())
                 .unitPrice(drink.getPrice())
                 .totalPrice(drink.getPrice() * cart.getQuantity())
+                .imageUrl(imageUrl)
                 .build();
     }
 

--- a/back/src/main/java/com/bubble/giju/domain/drink/repository/DrinkImageRepository.java
+++ b/back/src/main/java/com/bubble/giju/domain/drink/repository/DrinkImageRepository.java
@@ -1,14 +1,17 @@
 package com.bubble.giju.domain.drink.repository;
 
+import com.bubble.giju.domain.drink.entity.Drink;
 import com.bubble.giju.domain.drink.entity.DrinkImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface DrinkImageRepository extends JpaRepository<DrinkImage, Long> {
     DrinkImage findByDrinkIdAndThumbnailIsTrue(Long drinkId);
     List<DrinkImage> findByDrinkIdAndThumbnailIsFalse(Long drinkId);
+    Optional<DrinkImage> findFirstByDrinkAndThumbnailTrue(Drink drink);
 
 }

--- a/back/src/main/java/com/bubble/giju/domain/image/entity/Image.java
+++ b/back/src/main/java/com/bubble/giju/domain/image/entity/Image.java
@@ -2,6 +2,7 @@ package com.bubble.giju.domain.image.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,6 +19,7 @@ public class Image {
     @Column(name="image_url",length=255,nullable=false, unique=true)
     private String url;
 
+    @Builder
     public Image(String url) {
         this.url = url;
     }

--- a/back/src/main/java/com/bubble/giju/global/config/ErrorCode.java
+++ b/back/src/main/java/com/bubble/giju/global/config/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
 
     //권한 없음
     USER_UNAUTHORIZED("사용자가 권한이없음",HttpStatus.UNAUTHORIZED),
+    THUMBNAIL_IMAGE_NOT_FOUND("해당 상품의 썸네일 이미지를 찾을 수 없습니다",HttpStatus.NOT_FOUND),
 
 
     /**

--- a/back/src/test/java/com/bubble/giju/cart/service/CartServiceImplTest.java
+++ b/back/src/test/java/com/bubble/giju/cart/service/CartServiceImplTest.java
@@ -9,7 +9,10 @@ import com.bubble.giju.domain.cart.entity.Cart;
 import com.bubble.giju.domain.cart.repository.CartRepository;
 import com.bubble.giju.domain.cart.service.serviceImpl.CartServiceImpl;
 import com.bubble.giju.domain.drink.entity.Drink;
+import com.bubble.giju.domain.drink.entity.DrinkImage;
+import com.bubble.giju.domain.drink.repository.DrinkImageRepository;
 import com.bubble.giju.domain.drink.repository.DrinkRepository;
+import com.bubble.giju.domain.image.entity.Image;
 import com.bubble.giju.domain.user.dto.CustomPrincipal;
 import com.bubble.giju.domain.user.entity.User;
 import com.bubble.giju.domain.user.repository.UserRepository;
@@ -45,6 +48,12 @@ public class CartServiceImplTest {
 
     @Mock
     private UserRepository userRepository;
+
+    // drinkImageRepository는 일부 테스트에서만 사용되므로
+    // 사용되지 않아도 예외가 발생하지 않도록 lenient 옵션을 설정함
+    @Mock(lenient = true)
+    private DrinkImageRepository drinkImageRepository;
+
 
     @InjectMocks
     private CartServiceImpl cartService;
@@ -82,6 +91,20 @@ public class CartServiceImplTest {
 
         // 위에서 반환된 userId로 findById 하면 testUser가 반환
         when(userRepository.findById(userId)).thenReturn(Optional.of(testUser));
+
+        Image image = Image.builder()
+                .url("https://example.com/test-image.jpg")
+                .build();
+
+        DrinkImage mockThumbnail = DrinkImage.builder()
+                .drink(testDrink)
+                .image(image)
+                .isThumbnail(true)
+                .build();
+
+        when(drinkImageRepository.findFirstByDrinkAndThumbnailTrue(any()))
+                .thenReturn(Optional.of(mockThumbnail));
+
     }
 
     public class TestUtil {


### PR DESCRIPTION
## 📌 Summary
- 장바구니 항목 응답 DTO에 상품 썸네일 이미지를 포함하도록 기능 확장
- Drink → DrinkImage → Image 구조를 활용하여, 각 장바구니 항목 조회 시 이미지 URL을 함께 제공함

## ✅ Features
- #15 에서 수정
- CartItemResponseDto에 imageUrl 필드 추가
- toCartItemDto()에서 썸네일 이미지 URL 조회 로직 구현
- drinkImageRepository.findFirstByDrinkAndThumbnailTrue() 사용
- 없을 경우  THUMBNAIL_IMAGE_NOT_FOUND 커스텀 예외 발생
- 해당 로직을 사용하는 모든 장바구니 API(addToCart, getCartList, getBuyCartList)에서 이미지 URL 포함 응답

